### PR TITLE
Added #include "hpdf_objects.h" in "hpdf.h"

### DIFF
--- a/include/hpdf.h
+++ b/include/hpdf.h
@@ -19,6 +19,7 @@
 
 #include "hpdf_config.h"
 #include "hpdf_version.h"
+#include "hpdf_objects.h"
 
 #define HPDF_UNUSED(a) ((void)(a))
 


### PR DESCRIPTION
Added #include "hpdf_objects.h" in "hpdf.h" as proposed  by vdmit for fixing the demo compilation error
